### PR TITLE
Remove godep from ./build

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 
 echo "Building systemd-docker..."
-godep go build -o bin/systemd-docker .
+GOPATH=$(pwd)/Godeps/_workspace go build -o bin/systemd-docker .


### PR DESCRIPTION
It's unnecessary to use godep when all you need is to set GOPATH.
