### PR TITLE
Instantiate ListOpts

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func parseContext(args []string) (*Context, error) {
 
 	flags := flag.NewFlagSet("systemd-docker", flag.ContinueOnError)
 
-	var flCgroups opts.ListOpts
+	flCgroups := opts.NewListOpts(nil)
 
 	flags.StringVar(&c.PidFile, []string{"p", "-pid-file"}, "", "pipe file")
 	flags.BoolVar(&c.Logs, []string{"l", "-logs"}, true, "pipe logs")


### PR DESCRIPTION
Unfortunately, compiling and running systemd-docker using the vendored deps right now results in a panic. Apparently, I ended up inadvertently vendoring in a newer version of `github.com/docker/docker/opts` than was used to build systemd-docker originally. This upstream commit [0] is the culprit. Updating the usage of ListOpts fixes the panic.

[0] https://github.com/docker/docker/commit/6200002669874f3314856527fecd0c004060913c
