### PR TITLE
Changed polling to WaitContainer

### DIFF
--- a/main.go
+++ b/main.go
@@ -498,7 +498,7 @@ func keepAlive(c *Context) error {
 			}
 
 			if container.State.Running {
-				time.Sleep(INTERVAL * time.Millisecond)
+				client.WaitContainer(c.Id)
 			} else {
 				return nil
 			}


### PR DESCRIPTION
Is there a reason you chose polling the daemon instead of using WaitContainer? Since this spams the logs and I think uses more cpu, than we need to use, I tried changing it to WaitContainer and it worked without glitch so far.
I kept the for loop in case something goes wrong with WaitContainer.