### PR TITLE
Bump client API version to 1.12

### DIFF
--- a/main.go
+++ b/main.go
@@ -262,7 +262,7 @@ func getClient(c *Context) (*dockerClient.Client, error) {
 		endpoint = "unix:///var/run/docker.sock"
 	}
 
-	return dockerClient.NewVersionedClient(endpoint, "1.11")
+	return dockerClient.NewVersionedClient(endpoint, "1.12")
 }
 
 func getContainerPid(c *Context) (int, error) {


### PR DESCRIPTION
I'm not sure how to run the tests to see if this change breaks anything, my attempts so far gave me this:

```
$ go test main.go 
main.go:18:2: cannot find package "github.com/docker/docker/opts" in any of:
    /usr/lib/go/src/pkg/github.com/docker/docker/opts (from $GOROOT)
    ($GOPATH not set)
main.go:19:2: cannot find package "github.com/docker/docker/pkg/mflag" in any of:
    /usr/lib/go/src/pkg/github.com/docker/docker/pkg/mflag (from $GOROOT)
    ($GOPATH not set)
main.go:21:2: cannot find package "github.com/fsouza/go-dockerclient" in any of:
    /usr/lib/go/src/pkg/github.com/fsouza/go-dockerclient (from $GOROOT)
    ($GOPATH not set)
```

If you can point me in the direction of running the tests I'll run them and try to fix them if necessary.  I've zero experience of go though, so please bear with me.
