### PR TITLE
Bump client API version to 1.20

### DIFF
--- a/main.go
+++ b/main.go
@@ -262,7 +262,7 @@ func getClient(c *Context) (*dockerClient.Client, error) {
 		endpoint = "unix:///var/run/docker.sock"
 	}
 
-	return dockerClient.NewVersionedClient(endpoint, "1.12")
+	return dockerClient.NewVersionedClient(endpoint, "1.20")
 }
 
 func getContainerPid(c *Context) (int, error) {


### PR DESCRIPTION
After reading and searching and wishing and hoping that this wouldn't be necessary... it seems this is my only option.
