### PR TITLE
Switch to another fork of the mflag library

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/opts"
-	flag "github.com/docker/docker/pkg/mflag"
+	flag "github.com/weaveworks/docker/pkg/mflag"
 
 	dockerClient "github.com/fsouza/go-dockerclient"
 )


### PR DESCRIPTION
Docker removed their mflag library and moved to a library named cobra.  This change gets the tool back working